### PR TITLE
Fixes 3dgut / 3dgrt source dir

### DIFF
--- a/source/container/src/main.py
+++ b/source/container/src/main.py
@@ -1577,7 +1577,8 @@ if __name__ == "__main__":
                             shutil.copytree("outputs/unnamed/nerfacto/train-stage-1/nerfstudio_models", dest_dir, dirs_exist_ok=True)
                         elif str(config['MODEL']).lower() == "3dgut" or str(config['MODEL']).lower() == "3dgrt":
                             dest_dir = os.path.join(config['DATASET_PATH'], "3dgrut_models")
-                            src_dir = os.path.join(config['DATASET_PATH'], os.listdir(os.path.join(config['DATASET_PATH'], 'exports', 'train-stage-1')[0]))
+                            base_dir = os.path.join(config['DATASET_PATH'], 'exports', 'train-stage-1')
+                            src_dir = os.path.join(base_dir, os.listdir(base_dir)[0])
                             print(f"SOURCE_DIR={src_dir}")
                             os.makedirs(dest_dir, exist_ok=True)
                             shutil.copytree(src_dir, dest_dir, dirs_exist_ok=True)


### PR DESCRIPTION
*Issue #, if available: N/A*

*Description of changes: Fixes source directory when using 3dgut / 3dgrt as the current path being created leads to an error:  `join() argument must be str, bytes, or os.PathLike object, not 'list'`*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
